### PR TITLE
Adds the mandatory reason argument to the document delete request

### DIFF
--- a/src/Gateway/DocumentGateway.php
+++ b/src/Gateway/DocumentGateway.php
@@ -40,9 +40,9 @@ class DocumentGateway extends BaseGateway
      * @throws TwikeyException
      * @throws ClientExceptionInterface
      */
-    public function cancel($mndtId, $lang = 'en')
+    public function cancel($mndtId, $rsn, $lang = 'en')
     {
-        $response = $this->request('DELETE', sprintf("/creditor/mandate?mndtId=%s", $mndtId), [], $lang);
+        $response = $this->request('DELETE', sprintf("/creditor/mandate?mndtId=%s&rsn=%s", $mndtId, $rsn), [], $lang);
         $server_output = $this->checkResponse($response, "Cancel a mandate!");
         return json_decode($server_output);
     }

--- a/tests/Twikey/Api/TwikeyTest.php
+++ b/tests/Twikey/Api/TwikeyTest.php
@@ -73,7 +73,7 @@ class TwikeyTest extends TestCase
         $twikey->document->feed(new SampleDocumentCallback());
 
         // Remove the document again
-        $twikey->document->cancel($contract->mndtId);
+        $twikey->document->cancel($contract->mndtId, "cancel");
     }
 
     public function testCreateTransaction()


### PR DESCRIPTION
Hi! It seems that your mandate deletion [endpoint](https://www.twikey.com/api/index.html#cancel-a-mandate) expects a reason field as mandatory, but this was left behind in the client. Thanks, 