### PR TITLE
Fixes typo in mandates feed

### DIFF
--- a/src/Gateway/DocumentGateway.php
+++ b/src/Gateway/DocumentGateway.php
@@ -69,7 +69,7 @@ class DocumentGateway extends BaseGateway
                         $callback->handleNew($update);
                     } else if ($isUpdate) {
                         // handle update
-                        $callback->handleNew($update);
+                        $callback->handleUpdate($update);
                     } else if ($isCancel) {
                         // handle cancel
                         $callback->handleCancel($update);


### PR DESCRIPTION
Hi @koen-serry this is just a typo I guess, as you define three callback states for mandates. Thanks,