### PR TITLE
Introduces a refunds endpoint supporting the credit transfers feed

### DIFF
--- a/src/Callback/RefundCallback.php
+++ b/src/Callback/RefundCallback.php
@@ -1,9 +1,9 @@
 <?php
-namespace Twikey\Api\Helper;
+namespace Twikey\Api\Callback;
 
 /**
  * Interface RefundCallback
- * @package Twikey\Api\Helper
+ * @package Twikey\Api\Callback
  */
 interface RefundCallback
 {

--- a/src/Gateway/RefundGateway.php
+++ b/src/Gateway/RefundGateway.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Twikey\Api\Gateway;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Twikey\Api\Helper\RefundCallback;
+use Twikey\Api\TwikeyException;
+
+class RefundGateway extends BaseGateway
+{
+    public function __construct(ClientInterface $httpClient, string $endpoint, string $apikey)
+    {
+        parent::__construct($httpClient, $endpoint, $apikey);
+    }
+
+    /**
+     * Read until empty
+     * @throws TwikeyException
+     * @throws ClientExceptionInterface
+     */
+    public function feed(RefundCallback $callback, $lang = 'en')
+    {
+        $count = 0;
+        do {
+            $response = $this->request('GET', "/creditor/transfer", [], $lang);
+            $server_output = $this->checkResponse($response, "Retrieving credit transfer feed!");
+            $refunds = json_decode($server_output);
+            foreach ($refunds->Entries as $ct){
+                $count++;
+                $callback->handle($ct);
+            }
+        } while(count($refunds->Entries) > 0);
+        return $count;
+    }
+}

--- a/src/Gateway/RefundGateway.php
+++ b/src/Gateway/RefundGateway.php
@@ -3,16 +3,11 @@
 namespace Twikey\Api\Gateway;
 
 use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Client\ClientInterface;
-use Twikey\Api\Helper\RefundCallback;
+use Twikey\Api\Callback\RefundCallback;
 use Twikey\Api\TwikeyException;
 
 class RefundGateway extends BaseGateway
 {
-    public function __construct(ClientInterface $httpClient, string $endpoint, string $apikey)
-    {
-        parent::__construct($httpClient, $endpoint, $apikey);
-    }
 
     /**
      * Read until empty

--- a/src/Helper/RefundCallback.php
+++ b/src/Helper/RefundCallback.php
@@ -1,0 +1,11 @@
+<?php
+namespace Twikey\Api\Helper;
+
+/**
+ * Interface RefundCallback
+ * @package Twikey\Api\Helper
+ */
+interface RefundCallback
+{
+    public function handle($creditTransfer);
+}

--- a/src/Twikey.php
+++ b/src/Twikey.php
@@ -7,6 +7,7 @@ use Psr\Http\Client\ClientInterface;
 use Twikey\Api\Gateway\InvoiceGateway;
 use Twikey\Api\Gateway\LinkGateway;
 use Twikey\Api\Gateway\DocumentGateway;
+use Twikey\Api\Gateway\RefundGateway;
 use Twikey\Api\Gateway\TransactionGateway;
 use Twikey\Api\Exception\TwikeyException;
 
@@ -22,6 +23,7 @@ class Twikey
     public TransactionGateway $transaction;
     public LinkGateway $link;
     public InvoiceGateway $invoice;
+    public RefundGateway $refund;
 
     public function __construct(ClientInterface $httpClient, string $apikey, bool $testMode = false)
     {
@@ -34,6 +36,7 @@ class Twikey
         $this->transaction = new TransactionGateway($httpClient,$endpoint, $apiKey);
         $this->link = new LinkGateway($httpClient,$endpoint, $apiKey);
         $this->invoice = new InvoiceGateway($httpClient, $endpoint, $apiKey);
+        $this->refund = new RefundGateway($httpClient, $endpoint, $apiKey);
     }
 
     /**


### PR DESCRIPTION
Hi @koen-serry ,

I am not 100% sure the [credit transfer feed](https://www.twikey.com/api/index.html#refunds-credit-transfer) behaves exactly like the other feeds you've implemented already, the 'feed' word makes me think so. We'd like the very same callback approach though, to keep it consistent. By looking at the example, this endpoint just returns updates with no defined state.

Thanks! 