### PR TITLE
Allow overriding basic header parameters

### DIFF
--- a/src/Twikey.php
+++ b/src/Twikey.php
@@ -186,13 +186,13 @@ class Twikey
     {
         $fulluri = sprintf("%s%s", $this->endpoint, $uri);
         $headers = $options['headers'] ?? [];
-        $headers = array_merge($headers, [
+        $headers = array_merge([
             'Accept' => 'application/json',
             'Content-Type' => 'application/x-www-form-urlencoded',
             "User-Agent" => $this->user_agent,
             "Accept-Language" => $this->lang,
             "Authorization" => $this->refreshTokenIfRequired()
-        ]);
+        ], $headers);
         $options['headers'] = $headers;
         return $this->http_client->request($method, $fulluri, $options);
     }


### PR DESCRIPTION
Hi. 
I'm a backend developer at Striktly and we had an integration with Twikey. It was for us impossible to send the data for creating the invoice through `form_params` so we overrode the `InvoiceGateway` class to be able to send the body as json. This was possible until Friday 21th July.

We are not able to send the customer object as an array data unless it's send through content type json. I made this pull request to be able to manipulate the content type somehow without breaking the code for anyone else.