### PR TITLE
Move TWIKEY_DEBUG into a class constant to avoid namespace-const reso…

### DIFF
--- a/src/Twikey.php
+++ b/src/Twikey.php
@@ -17,11 +17,10 @@ use Twikey\Api\Gateway\RefundGateway;
 use Twikey\Api\Gateway\TransactionGateway;
 use Twikey\Api\Gateway\SubscriptionGateway;
 
-const TWIKEY_DEBUG = false;
-
 class Twikey
 {
     const VERSION = '0.4.1';
+    const DEBUG = false;
 
     private string $lang = 'en';
     private string $endpoint;
@@ -223,7 +222,7 @@ class Twikey
                 error_log(sprintf("%s : Error = %s (%s)", $context, $server_output, $this->endpoint), 0);
                 throw new TwikeyException("General error");
             }
-            if (TWIKEY_DEBUG) {
+            if (self::DEBUG) {
                 error_log(sprintf("Response %s : %s", $context, $server_output), 0);
             }
             return $server_output;


### PR DESCRIPTION
`TWIKEY_DEBUG` was declared as a bare namespace-level `const` outside the `Twikey` class, only used later in the same file. Reported by a customer as causing an intermittent `Undefined constant "Twikey\Api\TWIKEY_DEBUG"` fatal error in their environment.

This moves it into a class constant (`Twikey::DEBUG`) instead, keeping the same manual debug-toggle behavior while avoiding the namespace-level-constant resolution issue.